### PR TITLE
[1.0] Add a setting to set a separate endpoint for querying CPU price

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,3 +42,8 @@ EXPIRE_SEC=60
 
 # Whether local Leap node should retry when broadcasting failed.
 RETRY_TX=true
+
+# Endpoints used for querying CPU price. Mainly for tests. 
+# If it is not set or set to empty string, the RPC_ENDPOINT will be used. 
+# Only ONE url instead of a list should be put here.
+# PRICING_ENDPOINTS=http://127.0.0.1:8888

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ For every transaction that you relay you will receive a reward in the form of EO
 | `FIXED_MINER_FEE` | Fixed priority_fee in wei if MINER_FEE_MODE=`FIXED`. | 0 | 
 | `EXPIRE_SEC` | Expiration time when broadcasting EOS transaction. | 60 |
 | `RETRY_TX` | Whether local Leap node should retry when broadcasting failed. | true |
+| `PRICING_ENDPOINTS` | Endpoints used for querying CPU price. Mainly for tests. Only ONE url instead of a list should be put here. | null |
 
 ## Usage
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@enf/eos-evm-miner",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ const {
     GAS_TOKEN_EXCHANGE_RATE = 1, // If EOS is the gas token, the exchange rate is 1
     MINER_MARKUP_PERCENTAGE = 0,
     RETRY_TX = "true",
+    PRICING_ENDPOINTS,
 } = process.env;
 
 const quit = (error:string) => {
@@ -50,6 +51,7 @@ const eosEvmMiner = new EosEvmMiner({
     evmAccount: EVM_ACCOUNT,
     evmScope: EVM_SCOPE,
     retryTx: retryTx,
+    pricingEndpoings: PRICING_ENDPOINTS,
 });
 
 const server = new jayson.Server({

--- a/src/miner.ts
+++ b/src/miner.ts
@@ -20,6 +20,7 @@ export interface MinerConfig {
     evmAccount: string;
     evmScope: string;
     retryTx: boolean;
+    pricingEndpoings: string;
 }
 
 export default class EosEvmMiner {
@@ -202,11 +203,19 @@ export default class EosEvmMiner {
                 this.rpc = rpc;
                 logger.info("setting RPC endpoint to " + this.config.rpcEndpoints[i]);
 
-                this.resources = new Resources({
-                    api: this.rpc,
-                    sampleAccount: "eosio.reserv",
-                })
-
+                if (this.config.pricingEndpoings) {
+                    this.resources = new Resources({
+                        api: new APIClient({ url: this.config.pricingEndpoings }),
+                        sampleAccount: "eosio.reserv",
+                    })
+                }
+                else {
+                    this.resources = new Resources({
+                        api: this.rpc,
+                        sampleAccount: "eosio.reserv",
+                    })
+                }
+                
                 const session = new Session({
                     actor: this.config.minerAccount,
                     permission: this.config.minerPermission,


### PR DESCRIPTION
Mainly for tests so that we can use Mainnet CPU price as reference to determine Testnet price.

Resolve #52 