### PR TITLE
allow user to specify auth account which is different from miner account

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,11 +8,12 @@ import {logger} from "./logger";
 const { 
     PRIVATE_KEY, 
     MINER_ACCOUNT, 
+    AUTH_ACCOUNT = "", // account that authorize the tx, also pay cpu/net, default to miner
     RPC_ENDPOINTS, 
     PORT = 50305, 
     EVM_ACCOUNT = "eosio.evm",
     EVM_SCOPE = "eosio.evm",
-    MINER_PERMISSION = "active",
+    MINER_PERMISSION = "active", // permission to authorize the tx
     GAS_PER_US = 74,
     EXPIRE_SEC = 60,
     MINER_FEE_MODE = "fixed", // default to fixed 0 fee
@@ -41,6 +42,7 @@ const eosEvmMiner = new EosEvmMiner({
     privateKey: PRIVATE_KEY,
     minerAccount: MINER_ACCOUNT,
     minerPermission: MINER_PERMISSION,
+    authAccount: AUTH_ACCOUNT.length > 0 ? AUTH_ACCOUNT : MINER_ACCOUNT,
     rpcEndpoints,
     expireSec: +EXPIRE_SEC,
     minerFeeMode: MINER_FEE_MODE,
@@ -98,7 +100,8 @@ logger.info(`
 ███████╗╚██████╔╝███████║    ███████╗ ╚████╔╝ ██║ ╚═╝ ██║
 ╚══════╝ ╚═════╝ ╚══════╝    ╚══════╝  ╚═══╝  ╚═╝     ╚═╝
     EOS EVM Miner listening @ http://127.0.0.1:${colors.blue(PORT.toString())}    
-        Your miner account is ${colors.blue(MINER_ACCOUNT)}  
+        Your miner account is ${colors.blue(MINER_ACCOUNT)}
+        authentication is ${colors.blue(eosEvmMiner.config.authAccount)}@${colors.blue(eosEvmMiner.config.minerPermission)}  
 `);
 
 export { server, eosEvmMiner };

--- a/src/miner.ts
+++ b/src/miner.ts
@@ -10,6 +10,7 @@ export interface MinerConfig {
     privateKey: string;
     minerAccount: string;
     minerPermission: string;
+    authAccount: string;
     rpcEndpoints: Array<string>;
     expireSec: number;
     minerFeeMode: string;
@@ -217,7 +218,7 @@ export default class EosEvmMiner {
                 }
                 
                 const session = new Session({
-                    actor: this.config.minerAccount,
+                    actor: this.config.authAccount,
                     permission: this.config.minerPermission,
                     chain: {
                         id: info.chain_id,
@@ -248,7 +249,7 @@ export default class EosEvmMiner {
                     account: this.config.evmAccount,
                     name: "pushtx",
                     authorization: [{
-                        actor: this.config.minerAccount,
+                        actor: this.config.authAccount,
                         permission: this.config.minerPermission,
                     }],
                     data: {


### PR DESCRIPTION
Resolves #63 

This PR allow miners to use an account (that can be different from the miner account), to authenticate the transaction and pay cpu/net.

new config:

AUTH_ACCOUNT: account for authorizing the transaction, default to miner account
